### PR TITLE
feat: add support for Marked v15, v16, and v17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marked-more-lists",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "marked-more-lists",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.28.5",
@@ -27,7 +27,7 @@
         "semantic-release": "^25.0.2"
       },
       "peerDependencies": {
-        "marked": ">=14 <15"
+        "marked": ">=14 <18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -103,6 +103,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2781,6 +2782,7 @@
       "integrity": "sha512-ODsoD39Lq6vR6aBgvjTnA3nZGliknKboc9Gtxr7E4WDNqY24MxANKcuDQSF0jzapvGb3KWOEDrKfve4HoWGK+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.1",
@@ -4079,6 +4081,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz",
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -4555,6 +4558,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4901,6 +4905,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5675,6 +5680,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10467,6 +10473,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11561,6 +11568,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -11848,6 +11856,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12772,6 +12781,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13413,6 +13423,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -15282,6 +15293,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.2.tgz",
       "integrity": "sha512-ODsoD39Lq6vR6aBgvjTnA3nZGliknKboc9Gtxr7E4WDNqY24MxANKcuDQSF0jzapvGb3KWOEDrKfve4HoWGK+g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.1",
@@ -16168,6 +16180,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.3.tgz",
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -16437,7 +16450,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -16696,6 +16710,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
       "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -17231,6 +17246,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -20581,7 +20597,8 @@
             "picomatch": {
               "version": "4.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "peer": true
             }
           }
         },
@@ -21342,6 +21359,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.2.tgz",
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -21534,7 +21552,8 @@
           "version": "15.0.12",
           "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
           "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "marked-terminal": {
           "version": "7.3.0",
@@ -22175,7 +22194,8 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marked-more-lists",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "An extension for marked to support additional list styles",
   "main": "./lib/index.cjs",
   "module": "./src/index.js",
@@ -26,7 +26,13 @@
     "format": "eslint --fix",
     "lint": "eslint",
     "test": "jest --verbose",
-    "test:cover": "jest --coverage"
+    "test:cover": "jest --coverage",
+    "test:v14": "npm install marked@14 --no-save && npm test",
+    "test:v15": "npm install marked@15 --no-save && npm test",
+    "test:v16": "npm install marked@16 --no-save && npm test",
+    "test:v17": "npm install marked@17 --no-save && npm test",
+    "test:all-versions": "npm run test:v14 && npm run test:v15 && npm run test:v16 && npm run test:v17",
+    "test:current": "npm test"
   },
   "repository": {
     "type": "git",
@@ -39,7 +45,7 @@
   },
   "homepage": "https://github.com/jasny/marked-more-lists#readme",
   "peerDependencies": {
-    "marked": ">=14 <15"
+    "marked": ">=14 <18"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -46,7 +46,7 @@ look at the following list:
     </ol>
   </li>
   <li value="7">item 7
-      <ol type="A">
+      <ol start="2" type="A">
         <li value="2">item B</li>
         <li value="4">item D</li>
       </ol>
@@ -73,5 +73,40 @@ look at the following list:
   test('without this extension', () => {
     const result = marked(exampleMarkdown);
     expect(cleanHtml(result)).not.toBe(cleanHtml(expectedResult));
+  });
+
+  describe('start attribute tests', () => {
+    beforeEach(() => {
+      marked.setOptions(marked.getDefaults());
+      marked.use(markedMoreLists());
+    });
+
+    test('numeric list starting at 1 has no start attribute', () => {
+      const result = marked.parse('1. First\n2. Second');
+      expect(result).not.toContain('start=');
+    });
+
+    test('numeric list starting at 5 has start="5"', () => {
+      const result = marked.parse('5. Fifth\n6. Sixth');
+      expect(result).toContain('start="5"');
+    });
+
+    test('alphabetic list starting at e has start="5"', () => {
+      const result = marked.parse('e. Fifth\nf. Sixth');
+      expect(result).toContain('start="5"');
+      expect(result).toContain('type="a"');
+    });
+
+    test('Roman numeral list starting at v has start="5"', () => {
+      const result = marked.parse('v. Fifth\nvi. Sixth');
+      expect(result).toContain('start="5"');
+      expect(result).toContain('type="i"');
+    });
+
+    test('no start="undefined" in output', () => {
+      const result = marked.parse('1. First\na. Alpha\ni. Roman');
+      expect(result).not.toContain('start="undefined"');
+      expect(result).not.toContain('start="null"');
+    });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ export default function() {
             type: 'list',
             raw: '',
             ordered: isordered,
+            start: isordered ? null : undefined, // Initialize for ordered lists
             listType: type,
             loose: false,
             items: [],
@@ -243,6 +244,11 @@ export default function() {
               tokens: [],
             });
 
+            // Set list start from first item's value (only for ordered lists)
+            if (list.start === null && isordered && value !== null) {
+              list.start = value;
+            }
+
             expectedValue = value + 1;
 
             list.raw += raw;
@@ -280,6 +286,7 @@ export default function() {
       list(token) {
         const ordered = token.ordered;
         const listType = token.listType;
+        const start = token.start;
 
         let body = '';
         for (let j = 0; j < token.items.length; j++) {
@@ -288,8 +295,21 @@ export default function() {
         }
 
         const type = ordered ? 'ol' : 'ul';
-        const typeAttr = (ordered && listType !== '1') ? (' type="' + listType + '"') : '';
-        return '<' + type + typeAttr + '>\n' + body + '</' + type + '>\n';
+
+        // Build attributes
+        let attrs = '';
+
+        // Add start attribute for non-default values (not 1 or undefined)
+        if (ordered && start !== undefined && start !== null && start !== 1) {
+          attrs += ' start="' + start + '"';
+        }
+
+        // Add type attribute for non-numeric lists
+        if (ordered && listType !== '1') {
+          attrs += ' type="' + listType + '"';
+        }
+
+        return '<' + type + attrs + '>\n' + body + '</' + type + '>\n';
       },
       listitem(item) {
         let itemBody = '';


### PR DESCRIPTION
Add compatibility with Marked versions 15 through 17 while maintaining backward compatibility with v14. This resolves the issue where Marked v17's default renderer outputs 'start="undefined"' for list tokens that lack a start property.

Changes:
- Add 'start' property to list tokens for ordered lists
- Update list renderer to output 'start' attribute for non-default values
- Add comprehensive test cases for start attribute behavior
- Add multi-version testing scripts (test:v14, test:v15, test:v16, test:v17)
- Update peer dependency from '>=14 <15' to '>=14 <18'

The start property is set from the first list item's value and is properly
calculated for numeric (1, 2, 3), alphabetic (a, b, c), and Roman numeral
(i, ii, iii) lists. The renderer only outputs the start attribute when the
list begins at a non-default value (not 1) to keep HTML output clean.

All tests pass with Marked v14.x, v15.x, v16.x, and v17.x.