### PR TITLE
fix: render ordered list `start` correctly and prevent `start="undefined"` (PR #182)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/jasny/marked-more-lists#readme",
   "peerDependencies": {
-    "marked": ">=14 <15"
+    "marked": ">=14 <19"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -46,7 +46,7 @@ look at the following list:
     </ol>
   </li>
   <li value="7">item 7
-      <ol type="A">
+      <ol start="2" type="A">
         <li value="2">item B</li>
         <li value="4">item D</li>
       </ol>
@@ -74,4 +74,40 @@ look at the following list:
     const result = marked(exampleMarkdown);
     expect(cleanHtml(result)).not.toBe(cleanHtml(expectedResult));
   });
+
+  describe('start attribute tests', () => {
+    beforeEach(() => {
+      marked.setOptions(marked.getDefaults());
+      marked.use(markedMoreLists());
+    });
+
+    test('numeric list starting at 1 has no start attribute', () => {
+      const result = marked.parse('1. First\n2. Second');
+      expect(result).not.toContain('start=');
+    });
+
+    test('numeric list starting at 5 has start="5"', () => {
+      const result = marked.parse('5. Fifth\n6. Sixth');
+      expect(result).toContain('start="5"');
+    });
+
+    test('alphabetic list starting at e has start="5"', () => {
+      const result = marked.parse('e. Fifth\nf. Sixth');
+      expect(result).toContain('start="5"');
+      expect(result).toContain('type="a"');
+    });
+
+    test('Roman numeral list starting at v has start="5"', () => {
+      const result = marked.parse('v. Fifth\nvi. Sixth');
+      expect(result).toContain('start="5"');
+      expect(result).toContain('type="i"');
+    });
+
+    test('no start="undefined" in output', () => {
+      const result = marked.parse('1. First\na. Alpha\ni. Roman');
+      expect(result).not.toContain('start="undefined"');
+      expect(result).not.toContain('start="null"');
+    });
+  });
+
 });

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -109,5 +109,4 @@ look at the following list:
       expect(result).not.toContain('start="null"');
     });
   });
-
 });

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ export default function() {
             type: 'list',
             raw: '',
             ordered: isordered,
+            start: isordered ? null : undefined,
             listType: type,
             loose: false,
             items: [],
@@ -243,6 +244,10 @@ export default function() {
               tokens: [],
             });
 
+            if (list.start === null && isordered && value !== null) {
+              list.start = value;
+            }
+
             expectedValue = value + 1;
 
             list.raw += raw;
@@ -280,6 +285,7 @@ export default function() {
       list(token) {
         const ordered = token.ordered;
         const listType = token.listType;
+        const start = token.start;
 
         let body = '';
         for (let j = 0; j < token.items.length; j++) {
@@ -288,8 +294,16 @@ export default function() {
         }
 
         const type = ordered ? 'ol' : 'ul';
-        const typeAttr = (ordered && listType !== '1') ? (' type="' + listType + '"') : '';
-        return '<' + type + typeAttr + '>\n' + body + '</' + type + '>\n';
+
+        let attrs = '';
+        if (ordered && start !== undefined && start !== null && start !== 1) {
+          attrs += ' start="' + start + '"';
+        }
+        if (ordered && listType !== '1') {
+          attrs += ' type="' + listType + '"';
+        }
+
+        return '<' + type + attrs + '>\n' + body + '</' + type + '>\n';
       },
       listitem(item) {
         let itemBody = '';


### PR DESCRIPTION
### Motivation
- Prevent regressions where newer `marked` renderers output `start="undefined"` for ordered lists and restore explicit `start` handling for non-default list starts.
- Maintain compatibility with newer `marked` versions while preserving previous list `type` behavior.

### Description
- Initialize a `start` property on list tokens and set `list.start` from the first ordered list item's `value` in the tokenizer (`src/index.js`).
- Update the list renderer to emit a `start` attribute only when `ordered` and `start` is defined and not `1`, and continue to emit `type` for non-numeric ordered lists (`src/index.js`).
- Update the test fixture and add dedicated tests for numeric, alphabetic, and Roman lists and to guard against `start="undefined"` / `start="null"` in output (`spec/index.test.js`).
- Broaden the `marked` peer dependency range in `package.json` to include newer versions (`"marked": ">=14 <19"`).

### Testing
- Ran `npm test` (Jest) which completed successfully with `1` test suite and `7` tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa9f9ceb48320918a854e9c23f2f1)