### PR TITLE
ci: switch release workflow to GitHub OIDC and tighten workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
 
@@ -53,13 +53,17 @@ jobs:
       - name: Build 🗜️
         run: npm run build
 
-  ############ Requires NPM_TOKEN in secrets ############
   Release:
     needs: [Test, Lint, Build]
     if: |
       github.ref == 'refs/heads/main' &&
       github.event.repository.fork == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -67,6 +71,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install Dependencies
         run: npm ci
       - name: Build 🗜️
@@ -74,5 +79,4 @@ jobs:
       - name: Release 🎉
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
### Motivation
- Migrate publishing from long-lived `NPM_TOKEN` to GitHub OIDC trusted publishing to improve security.
- Reduce top-level workflow privileges by setting `permissions: contents: read` and confining elevated permissions to the release job.
- Preserve `semantic-release`'s ability to update releases and PRs while avoiding broad repository write access.

### Description
- Changed top-level `permissions` in `.github/workflows/main.yml` from `contents: write` to `contents: read`.
- Added job-level `permissions` to the `Release` job including `id-token: write`, `contents: write`, `issues: write`, and `pull-requests: write`.
- Removed `NPM_TOKEN` from the `Release` environment and added `registry-url: 'https://registry.npmjs.org'` to `actions/setup-node` so publishing uses GitHub OIDC with `semantic-release`.

### Testing
- No automated tests were executed as part of this change; existing CI jobs (`Test`, `Lint`, `Build`) remain in the workflow and will run `npm ci`, `npm run test`, `npm run lint`, and `npm run build` when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0062981c5083208637c3979cc3d9dc)